### PR TITLE
Update uniqid to ^3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
   "repository": "postcss/postcss-filter-plugins",
   "dependencies": {
     "postcss": "^5.0.4",
-    "uniqid": "^1.0.0"
+    "uniqid": "^3.0.0"
   }
 }


### PR DESCRIPTION
I ran into a problem when using fake timers in a test that involves postcss-filter-plugins because the 1.x series of uniqid uses a busy loop in its id generation, waiting for `new Date().getTime()` to increase: https://github.com/adamhalasz/uniqid/blob/40bb1c764548a58da574c3860127b7e0ed81255c/index.js#L16

Luckily that was fixed in https://github.com/adamhalasz/uniqid/pull/3, which made it into version 3.x, so it's just a matter of upgrading. Tests still pass -- and seem to run about 25% faster, unsurprisingly :)
