### PR TITLE
Fix critical vulnerability CWE-78

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,8 +44,7 @@
   },
   "repository": "postcss/postcss-filter-plugins",
   "dependencies": {
-    "postcss": "^6.0.14",
-    "uniqid": "^4.0.0"
+    "postcss": "^6.0.14"
   },
   "ava": {
     "require": "babel-register"

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import postcss from 'postcss';
-import uniqid from 'uniqid';
+
+function guid(a){return a?(a^Math.random()*16>>a/4).toString(16):([1e7]+-1e3+-4e3+-8e3+-1e11).replace(/[018]/g,guid)}
 
 export default postcss.plugin('postcss-filter-plugins', ({
     template = ({postcssPlugin}) => `Found duplicate plugin: ${postcssPlugin}`,
@@ -7,7 +8,7 @@ export default postcss.plugin('postcss-filter-plugins', ({
     exclude = [],
     direction = 'both',
 } = {}) => {
-    const id = uniqid();
+    const id = guid();
     let prev, next, both;
 
     switch (direction) {


### PR DESCRIPTION
Since the uniqid package depends (sadly) on macaddress, it causes https://nodesecurity.io/advisories/654 to pop up in the npm security audits of the huge amount of packages that depend on postcss-filter-plugins. A hardware-based ID wasn't really needed, so I replaced it with (version 4) UUIDs which will be just as unique.