### PR TITLE
CWE-78 fix for v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.0.3
+
+* Remove vulnerable downstream dependency
+
 # 2.0.2
 
 * Bumped uniqid to `4.0.0`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-filter-plugins",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Exclude/warn on duplicated PostCSS plugins.",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -45,8 +45,7 @@
   },
   "repository": "postcss/postcss-filter-plugins",
   "dependencies": {
-    "postcss": "^5.0.4",
-    "uniqid": "^4.0.0"
+    "postcss": "^5.0.4"
   },
   "ava": {
     "require": "babel-register"

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,4 @@
 import postcss from 'postcss';
-import uniqid from 'uniqid';
 
 export default postcss.plugin('postcss-filter-plugins', ({
     template = ({postcssPlugin}) => `Found duplicate plugin: ${postcssPlugin}`,
@@ -7,7 +6,7 @@ export default postcss.plugin('postcss-filter-plugins', ({
     exclude = [],
     direction = 'both',
 } = {}) => {
-    const id = uniqid();
+    const id = Math.random().toString();
     let prev, next, both;
 
     switch (direction) {


### PR DESCRIPTION
I use a package (css-loader) which indirectly depends on v2 of postcss-filter-plugins, so porting the cwe-78 fix to the older version would fix the audit warnings for myself and the many other people who use css-loader, or current versions of cssnano.

I literally just cherry-picked the changes from 3.0.1 onto 2.0.2.

(looks like y'all don't have a branch for v2, and I guess github doesn't have a way to suggest creating a new branch in the base repository? strange.)