### PR TITLE
Adding ppc64le architecture support on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,10 @@ node_js:
   - 8
   - 6
   - 4
+arch:
+  - amd64
+  - ppc64le
+matrix:
+    exclude:
+         - arch: ppc64le
+           node_js: "4"


### PR DESCRIPTION
Hi,
I had added ppc64le(Linux on Power) architecture support on travis-ci in the PR and looks like its been successfully added. I believe it is ready for the final review and merge. Travis build: https://www.travis-ci.com/github/kishorkunal-raj/postcss-filter-plugins/builds/210220862

Reason behind running tests on ppc64le: This package is included in the ppc64le versions of RHEL and Ubuntu - this allows the top of tree to be tested continuously as it is for Intel, making it easier to catch any possible regressions on ppc64le before the distros begin their clones and builds. This reduces the work in integrating this package into future versions of RHEL/Ubuntu.

Please have a look.

Regards,
Kishor Kunal Raj